### PR TITLE
SPI segfault fix

### DIFF
--- a/library/ST7735/__init__.py
+++ b/library/ST7735/__init__.py
@@ -206,10 +206,7 @@ class ST7735(object):
         # Convert scalar argument to list so either can be passed as parameter.
         if isinstance(data, numbers.Number):
             data = [data & 0xFF]
-        # Write data a chunk at a time.
-        for start in range(0, len(data), chunk_size):
-            end = min(start + chunk_size, len(data))
-            self._spi.xfer(data[start:end])
+        self._spi.xfer3(data)
 
     def set_backlight(self, value):
         """Set the backlight on/off."""

--- a/library/setup.py
+++ b/library/setup.py
@@ -19,4 +19,5 @@ setup(name='ST7735',
       author_email='phil@pimoroni.com',
       classifiers=classifiers,
       url='https://github.com/pimoroni/st7735-160x80-python/',
-      packages=find_packages())
+      packages=find_packages(),
+      install_requires=['spidev>=3.4'])


### PR DESCRIPTION
This has been tested with dummy data (avoiding numpy and PIL) for over 1.8 million display updates without issue.

This fix should address issues reported with Mopidy PiDi (pimoroni/mopidy-pidi#3) and Enviro+ (pimoroni/enviroplus-python#42).