### PR TITLE
Add py3 debian dependencies

### DIFF
--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -47,6 +47,9 @@ py2deps =
     python-pil
 py3deps =
     python3-pil
+    python3-numpy
+    python3-spidev
+    python3-rpi.gpio
 configtxt =
 commands =
 	printf "Setting up SPI...\n"


### PR DESCRIPTION
These python modules are directly used from this library so dependencies should be expressed.
Might be worth consider adding them to `install_requires` as well.
